### PR TITLE
[Notifier] Enable auto-configuration for the `GoIP` bridge  in `notifier.yaml`

### DIFF
--- a/symfony/goip-notifier/6.4/manifest.json
+++ b/symfony/goip-notifier/6.4/manifest.json
@@ -1,4 +1,13 @@
 {
+    "add-lines": [
+        {
+            "file": "config/packages/notifier.yaml",
+            "position": "after_target",
+            "warn_if_missing": true,
+            "target": "        texter_transports:",
+            "content": "            goip: '%env(GOIP_DSN)%'"
+        }
+    ],
     "env": {
         "#1": "GOIP_DSN=goip://USERNAME:PASSWORD@HOST:80?sim_slot=SIM_SLOT"
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  |

This has been forgotten to be set/enabled when the recipe was introduced for the first time.